### PR TITLE
updated revision of LCD1602+Project Board changed LCD address to 0x3F  (previously 0x27)

### DIFF
--- a/Sketches/Sketch_18.2_LCD1602_Clock/Sketch_18.2_LCD1602_Clock.ino
+++ b/Sketches/Sketch_18.2_LCD1602_Clock/Sketch_18.2_LCD1602_Clock.ino
@@ -9,7 +9,7 @@
 #include <FlexiTimer2.h>      // Contains FlexiTimer2 Library
 
 // initialize the library with the numbers of the interface pins
-LiquidCrystal_I2C lcd(0x27, 16, 2);
+LiquidCrystal_I2C lcd(0x3f, 16, 2);
 int tempPin = 0;                // define the pin of temperature sensor
 float tempVal;                  // define a variable to store temperature value
 int hour, minute, second;       // define variables stored record time


### PR DESCRIPTION
Latest rev of Freenove Project  Board + LCD has a different address for the lcd 1602. 
